### PR TITLE
Business User Authentication

### DIFF
--- a/core/src/main/java/repository/interfaces/IAdminManager.java
+++ b/core/src/main/java/repository/interfaces/IAdminManager.java
@@ -1,0 +1,14 @@
+package repository.interfaces;
+
+import repository.pojos.Admin;
+
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+
+public interface IAdminManager extends IManager {
+    Admin getAdminById(int adminId) throws SQLException;
+    Admin getAdminByUsername(String username) throws SQLException;
+    String login(String username, String password) throws SQLException, NoSuchAlgorithmException;
+    boolean validateToken(String username, String token) throws SQLException;
+    boolean logout(String username) throws SQLException;
+}

--- a/core/src/main/java/repository/pojos/Admin.java
+++ b/core/src/main/java/repository/pojos/Admin.java
@@ -1,0 +1,62 @@
+package repository.pojos;
+
+import java.time.LocalDateTime;
+
+public class Admin {
+    private Integer adminId;
+    private String username;
+    private String password;
+    private String token;
+    private LocalDateTime tokenCreated;
+
+    public Admin() { }
+
+    public Admin(Integer adminId, String username, String password, String token, LocalDateTime tokenCreated) {
+        this.adminId = adminId;
+        this.username = username;
+        this.password = password;
+        this.token = token;
+        this.tokenCreated = tokenCreated;
+    }
+
+
+    public Integer getAdminId() {
+        return adminId;
+    }
+
+    public void setAdminId(Integer adminId) {
+        this.adminId = adminId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public LocalDateTime getTokenCreated() { return tokenCreated; }
+
+    public void setTokenCreated(LocalDateTime tokenCreated) { this.tokenCreated = tokenCreated; }
+
+    public String toString() {
+        return String.format("ID: %d, USERNAME: %s", adminId, username);
+    }
+}

--- a/implementation/src/main/java/database/dao/AdminDAO.java
+++ b/implementation/src/main/java/database/dao/AdminDAO.java
@@ -1,0 +1,70 @@
+package database.dao;
+
+import database.db.DBConnection;
+import repository.pojos.Admin;
+
+import java.sql.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class AdminDAO {
+    public static Admin selectAdminById(int adminId) throws SQLException {
+        Connection conn = DBConnection.getConnection();
+        String sql = "SELECT * FROM Admin WHERE id = ?";
+
+        PreparedStatement stmt = conn.prepareStatement(sql);
+        stmt.setInt(1, adminId);
+        ResultSet rs = stmt.executeQuery();
+
+        if (!rs.next())
+            return null;
+
+        return mapResultSetToAdmin(rs);
+    }
+
+    public static Admin selectAdminByUsername(String username) throws SQLException {
+        Connection conn = DBConnection.getConnection();
+        String sql = "SELECT * FROM Admin WHERE username = ?";
+
+        PreparedStatement stmt = conn.prepareStatement(sql);
+        stmt.setString(1, username);
+        ResultSet rs = stmt.executeQuery();
+
+        if (!rs.next())
+            return null;
+
+        return mapResultSetToAdmin(rs);
+    }
+
+    public static Integer updateAdmin(int adminId, String token, LocalDateTime tokenCreated) throws SQLException {
+        Connection conn = DBConnection.getConnection();
+        String sql = "UPDATE Admin SET token = ?, token_created = ? WHERE id = ?";
+        Timestamp timestampTokenCreated = tokenCreated == null ? null : Timestamp.valueOf(tokenCreated);
+
+        PreparedStatement stmt = conn.prepareStatement(sql);
+        stmt.setString(1, token);
+        stmt.setTimestamp(2, timestampTokenCreated);
+        stmt.setInt(3, adminId);
+        int row = stmt.executeUpdate();
+
+        if(row <= 0)
+            return null;
+
+        return adminId;
+    }
+
+    private static Admin mapResultSetToAdmin(ResultSet rs) throws SQLException {
+        Admin admin = new Admin();
+        Timestamp timestampTokenCreated = rs.getTimestamp("token_created");
+
+        admin.setAdminId(rs.getInt("id"));
+        admin.setUsername(rs.getString("username"));
+        admin.setPassword(rs.getString("password"));
+        admin.setToken(rs.getString("token"));
+
+        if(timestampTokenCreated != null)
+            admin.setTokenCreated(timestampTokenCreated.toLocalDateTime());
+
+        return admin;
+    }
+}

--- a/implementation/src/main/java/factories/ManagerFactory.java
+++ b/implementation/src/main/java/factories/ManagerFactory.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Constructor;
 
 public enum ManagerFactory {
     GoogleSSOManager("GoogleSSOManagerImpl"),
+    AdminManager("AdminManagerImpl"),
     UserManager("UserManagerImpl"),
     CalendarManager("CalendarManagerImpl");
 

--- a/implementation/src/main/java/impl/AdminManager.java
+++ b/implementation/src/main/java/impl/AdminManager.java
@@ -1,0 +1,96 @@
+package impl;
+
+import database.dao.AdminDAO;
+import repository.interfaces.IAdminManager;
+import repository.pojos.Admin;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+
+public class AdminManager implements IAdminManager {
+    private static final int TOKEN_LENGTH = 20;
+
+    public Admin getAdminById(int adminId) throws SQLException {
+        return AdminDAO.selectAdminById(adminId);
+    }
+
+    public Admin getAdminByUsername(String username) throws SQLException {
+        return AdminDAO.selectAdminByUsername(username);
+    }
+
+    public String login(String username, String password) throws SQLException, NoSuchAlgorithmException {
+        Admin admin = getAdminByUsername(username);
+
+        if(admin == null)
+            return null;
+        else if(!admin.getPassword().equals(encryptPassword(password)))
+            return null;
+
+        String token = generateToken();
+        AdminDAO.updateAdmin(admin.getAdminId(), token, LocalDateTime.now());
+
+        return token;
+    }
+
+    public boolean validateToken(String username, String token) throws SQLException {
+        Admin admin = getAdminByUsername(username);
+
+        if(admin == null)
+            return false;
+        else if(admin.getToken() == null || !admin.getToken().equals(token))
+            return false;
+        else if(admin.getTokenCreated().plusMinutes(30).isBefore(LocalDateTime.now()))
+            return false;
+
+        return true;
+    }
+
+    public boolean logout(String username) throws SQLException {
+        Admin admin = getAdminByUsername(username);
+
+        if(admin == null)
+            return false;
+
+        return AdminDAO.updateAdmin(admin.getAdminId(), null, null) != null;
+    }
+
+    private String generateToken() {
+        String CHAR_LOWER = "zyxwvutsrqponmlkjihgfedcba";
+        String CHAR_UPPER = CHAR_LOWER.toUpperCase();
+        String NUMBER = "9876543210";
+        String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
+
+        StringBuilder sb = new StringBuilder(TOKEN_LENGTH);
+        SecureRandom random = new SecureRandom();
+        for (int i = 0; i < TOKEN_LENGTH; i++) {
+            // 0-62 (exclusive), random returns 0-61
+            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
+            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+            sb.append(rndChar);
+        }
+
+        return sb.toString();
+    }
+
+    private String encryptPassword(String password) throws NoSuchAlgorithmException {
+        // Create MessageDigest instance for MD5
+        MessageDigest md = MessageDigest.getInstance("MD5");
+
+        // Add password bytes to digest
+        md.update(password.getBytes());
+
+        // Get the hash's bytes
+        byte[] bytes = md.digest();
+
+        // Convert to hexadecimal format
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++)
+            sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
+
+        // Get complete hashed password in hex format
+        return sb.toString();
+    }
+}

--- a/implementation/src/main/resources/config.json
+++ b/implementation/src/main/resources/config.json
@@ -1,5 +1,6 @@
 {
   "GoogleSSOManagerImpl": "impl.GoogleSSOManager",
+  "AdminManagerImpl": "impl.AdminManager",
   "UserManagerImpl": "impl.UserManager",
   "CalendarManagerImpl": "impl.CalendarAPIManager"
 }

--- a/implementation/src/main/resources/db_config.json
+++ b/implementation/src/main/resources/db_config.json
@@ -1,7 +1,7 @@
 {
   "jdbcDriver": "com.mysql.cj.jdbc.Driver",
   "dbHost": "jdbc:mysql://localhost:3306/",
-  "dbName": "a3",
+  "dbName": "message_board",
   "dbUser": "test",
   "dbPassword": "QwErT1@3"
 }

--- a/implementation/src/main/resources/db_config.json
+++ b/implementation/src/main/resources/db_config.json
@@ -1,7 +1,7 @@
 {
   "jdbcDriver": "com.mysql.cj.jdbc.Driver",
   "dbHost": "jdbc:mysql://localhost:3306/",
-  "dbName": "message_board",
+  "dbName": "a3",
   "dbUser": "test",
   "dbPassword": "QwErT1@3"
 }

--- a/implementation/src/main/resources/db_create.sql
+++ b/implementation/src/main/resources/db_create.sql
@@ -1,3 +1,12 @@
+CREATE TABLE Admin(
+    id INT NOT NULL AUTO_INCREMENT,
+    username VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    token VARCHAR(255),
+    token_created DATETIME,
+    CONSTRAINT PK_id PRIMARY KEY(id)
+);
+
 CREATE TABLE User(
     id INT NOT NULL AUTO_INCREMENT,
     email VARCHAR(255) NOT NULL,
@@ -22,6 +31,8 @@ CREATE TABLE Appointment(
     CONSTRAINT FK_resourceId FOREIGN KEY (resourceId) REFERENCES Resource(id),
     CONSTRAINT FK_userId FOREIGN KEY (userId) REFERENCES User(id)
 );
+
+INSERT INTO Admin (username, password) VALUES ("admin", "21232f297a57a5a743894a0e4a801fc3");
 
 INSERT INTO User (email, token) VALUES ("user1@gmail.com", "token1");
 INSERT INTO User (email, token) VALUES ("user2@gmail.com", "token2");

--- a/service/src/main/java/com/example/rest/AdminRest.java
+++ b/service/src/main/java/com/example/rest/AdminRest.java
@@ -1,0 +1,73 @@
+package com.example.rest;
+
+import factories.ManagerFactory;
+import repository.interfaces.IAdminManager;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("admin")
+public class AdminRest {
+    IAdminManager adminManager = (IAdminManager) ManagerFactory.AdminManager.getManager();
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("login")
+    public Response login(@FormParam("username") String username, @FormParam("password") String password) {
+        try {
+            String token = adminManager.login(username, password);
+            if(token == null)
+                return Response.status(Response.Status.FORBIDDEN)
+                        .build();
+
+            return Response.status(Response.Status.OK)
+                    .entity(token)
+                    .build();
+        } catch(Exception e) {
+            e.printStackTrace();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .build();
+        }
+    }
+
+    // Same with UserRest's authenticate, just putting this so that using either this or Manager is available
+    @POST
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
+    @Path("auth")
+    public Response authenticate(@HeaderParam("x-api-key") String token, @FormParam("username") String username) {
+        try {
+            return Response.status(Response.Status.OK)
+                    .entity(adminManager.validateToken(username, token))
+                    .build();
+        } catch(Exception e) {
+            e.printStackTrace();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .build();
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("logout")
+    public Response logout(@HeaderParam("x-api-key") String token, @FormParam("username") String username) {
+        try {
+            boolean validated = adminManager.validateToken(username, token);
+            if(!validated)
+                return Response.status(Response.Status.FORBIDDEN)
+                        .build();
+
+            boolean success = adminManager.logout(username);
+            if(!success)
+                throw new Exception("Failed to logout");
+
+            return Response.status(Response.Status.OK)
+                    .entity("You have been logged out")
+                    .build();
+        } catch(Exception e) {
+            e.printStackTrace();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
Authentication for business users (called them admin)
Basically the same as the last client authentication PR but for admins
<br />

<ins>New DB Table</ins>
- Admin (check `db_create.sql` for CREATE and INSERT statement)
  - Password is `admin`
<br />

<ins>New Endpoints</ins>:
- `/admin/login `
  - non-SSO
  - No need to use a browser
  - Generates a token, stores in DB and returns it in Response (copy this to call auth or logout)
- `/admin/auth`
  - Same as `/user/auth`
- `/admin/logout`
  - Same as `/user/logout`